### PR TITLE
fix: add support for FontAwesome v6 style tags

### DIFF
--- a/fonts.user.styl
+++ b/fonts.user.styl
@@ -24,6 +24,7 @@
     // Exclude icon fonts.
     n += ':not(.i):not(.icon)'
     n += ':not(.fa):not(.fab):not(.fad):not(.fal):not(.far):not(.fas)'
+    n += ':not(.fa-solid):not(.fa-regular):not(.fa-light):not(.fa-duotone):not(.fa-thin):not(.fa-sharp):not(.fa-brands)
     n += ':not([class*="octicon-"])' // github
     n += ':not(.glyphicon)' // searx
     n += ':not([aria-hidden=true])' // google meet

--- a/fonts.user.styl
+++ b/fonts.user.styl
@@ -24,7 +24,7 @@
     // Exclude icon fonts.
     n += ':not(.i):not(.icon)'
     n += ':not(.fa):not(.fab):not(.fad):not(.fal):not(.far):not(.fas)'
-    n += ':not(.fa-solid):not(.fa-regular):not(.fa-light):not(.fa-duotone):not(.fa-thin):not(.fa-sharp):not(.fa-brands)
+    n += ':not(.fa-solid):not(.fa-regular):not(.fa-light):not(.fa-duotone):not(.fa-thin):not(.fa-sharp):not(.fa-brands)'
     n += ':not([class*="octicon-"])' // github
     n += ':not(.glyphicon)' // searx
     n += ':not([aria-hidden=true])' // google meet


### PR DESCRIPTION
Add the new style tags from FontAwesome v6 to fix overrides on sites using the newer FA stylesheets.