### PR TITLE
exclude mathjax formulas

### DIFF
--- a/fonts.user.styl
+++ b/fonts.user.styl
@@ -95,6 +95,9 @@
     // Exclude utility classes for fonts.
     n += ':not(.monospace):not(.text-mono)'
 
+    // mathjax
+    n += ':not(mjx-math *)'
+
     // Feat: use mono font in input areas.
     if inputs {
         // Exclude inputs of button type. #6


### PR DESCRIPTION
Mathjax depends on their own font and it looks weird when using the custom font.
See https://www.mathjax.org/#samples